### PR TITLE
feat: added global renovate configuration

### DIFF
--- a/ns8.json
+++ b/ns8.json
@@ -1,0 +1,33 @@
+{
+    "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+    "extends": [
+        "local>NethServer/.github:renovate-config",
+        ":disableDependencyDashboard"
+    ],
+    "branchPrefix": "renovate-",
+    "branchNameStrict": true,
+    "ignorePaths": [
+        "**/ui/**"
+    ],
+    "customManagers": [
+        {
+            "customType": "regex",
+            "fileMatch": [
+                "^build-images?\\.sh$"
+            ],
+            "matchStrings": [
+                "docker\\.io\/(?:library\/)?(?<depName>.+):(?<currentValue>[-0-9\\.a-z]+)",
+                "(?<depName>ghcr\\.io\/.+):(?<currentValue>[-0-9\\.a-z]+)"
+            ],
+            "datasourceTemplate": "docker"
+        }
+    ],
+    "packageRules": [
+        {
+            "matchPackageNames": [
+                "node"
+            ],
+            "allowedVersions": "<=18"
+        }
+    ]
+}

--- a/renovate-config.json
+++ b/renovate-config.json
@@ -1,0 +1,6 @@
+{
+   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+   "extends": [
+      "config:recommended"
+   ]
+}


### PR DESCRIPTION
Adding global configuration of renovate requested by @DavidePrincipi 

Once you onboard a repository under `NethServer` org, now renovate will automatically pull the preset coming from `renovate-config.json` and generate the base `renovate.json` like this:

```json
{
  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
  "extends": [
    "local>NethServer/.github:renovate-config"
  ]
}
```

Now, you can replace the `:renovate-config` with `:ns8` to have the following base configuration:

- All configuration coming from `renovate-config.json`
- Dependency dashboard disabled
- Branch prefixes changed to `renovate-` and replace of `.` characters to avoid breaking the build process of modules
- Ignoring paths `**/ui**`, this includes any `npm` dependency regards the UI of the module.
- Custom manager for `build-images.sh`, parses automatically images from `docker.io` and `ghcr.io`, you can then reference the images inside a `packageRules` section using `matchDepName` or `matchPackageNames` (please refer to the documentation as why they're two different names)
- Avoid node from being updated to versions higher than 18 (this might be overridden per-repo if there's the need for a greater node version)
