### PR TITLE
fix(renovate): updating regex for better parsing

### DIFF
--- a/ns8.json
+++ b/ns8.json
@@ -16,8 +16,8 @@
                 "^build-images?\\.sh$"
             ],
             "matchStrings": [
-                "docker\\.io\/(?:library\/)?(?<depName>.+):(?<currentValue>[-0-9\\.a-z]+)",
-                "(?<depName>ghcr\\.io\/.+):(?<currentValue>[-0-9\\.a-z]+)"
+                "docker\\.io\\/(?:library\\/)?(?<depName>[-0-9a-z_\\/.]+):(?<currentValue>[-0-9a-zA-Z_.]+)",
+                "(?<depName>ghcr\\.io\\/[-0-9a-z_\\/.]+):(?<currentValue>[-0-9a-zA-Z_.]+)"
             ],
             "datasourceTemplate": "docker"
         }


### PR DESCRIPTION
Found out that `.` was too wide, looked up image tagging specification and image repository specification to match correctly the format.