### PR TITLE
fix: match core build/test deps

### DIFF
--- a/ns8.json
+++ b/ns8.json
@@ -13,8 +13,8 @@
         {
             "customType": "regex",
             "fileMatch": [
-                "^test-module\\.sh$",
-                "^build-images?\\.sh$"
+                "(^|/)test-module\\.sh$",
+                "(^|/)build-images?\\.sh$"
             ],
             "matchStrings": [
                 "docker\\.io\\/(?:library\\/)?(?<depName>[-0-9a-z_\\/.]+):(?<currentValue>[-0-9a-zA-Z_.]+)",


### PR DESCRIPTION
The core repository has a different layout: shell scripts with dependencies are under the core/ directory. Fix the regexp to match both root and subdir paths.