### PR TITLE
feat: auto merge patch updates

### DIFF
--- a/ns8-automerge.json
+++ b/ns8-automerge.json
@@ -1,0 +1,7 @@
+{
+    "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+    "extends": [
+        "local>NethServer/.github:ns8",
+        ":automergePatch"
+    ]
+}


### PR DESCRIPTION
Automatically merge non-breaking patch updates.

Enable this base config with

```diff
diff --git a/renovate.json b/renovate.json
index 8d52000..157cf0e 100644
--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "local>NethServer/.github:ns8"
+    "local>NethServer/.github:ns8-automerge"
   ],
   "customManagers": [
     {
```