### PR TITLE
fix: enable npm updates, but exclude major bumps

### DIFF
--- a/ns8.json
+++ b/ns8.json
@@ -59,15 +59,14 @@
     ],
     "packageRules": [
         {
-            "matchPackageNames": [
-                "node",
-                "mcr.microsoft.com/devcontainers/javascript-node"
-            ],
-            "allowedVersions": "<=18"
-        },
-        {
             "matchDatasources": ["npm"],
-            "enabled": false
+            "matchUpdateTypes": ["major"],
+            "enabled": false,
+            "description": "Disable major version upgrades for all npm packages"
         }
-    ]
+    ],
+    "lockFileMaintenance": {
+        "enabled": true,
+        "schedule": ["before 5am on the first day of the month"]
+    }
 }


### PR DESCRIPTION
- Enable npm package updates
- Exclude major version updates: useful for many packages used in NS8 modules, e.g.:
  - vue
  - @vue/cli
  - @carbon/vue
  - vuex
  - vue-i18n
  - ...
- Enable lock file maintenance
- Remove node 18 version constraint: if some NS8 modules will have troubles upgrading we'll close that specific PR