### PR TITLE
feat: add renovate presets base and vue3

### DIFF
--- a/base.json
+++ b/base.json
@@ -1,0 +1,9 @@
+{
+    "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+    "extends": [
+        "config:recommended",
+        ":disableDependencyDashboard",
+        ":enableVulnerabilityAlerts"
+    ],
+    "osvVulnerabilityAlerts": true
+}

--- a/ns8.json
+++ b/ns8.json
@@ -1,8 +1,8 @@
 {
     "$schema": "https://docs.renovatebot.com/renovate-schema.json",
     "extends": [
-        "config:recommended",
-        ":disableDependencyDashboard"
+        "local>NethServer/.github:base",
+        ":maintainLockFilesMonthly"
     ],
     "branchPrefix": "renovate-",
     "branchNameStrict": true,
@@ -10,7 +10,6 @@
         "enabled": true,
         "ignoreDeps": ["vue"]
     },
-    "osvVulnerabilityAlerts": true,
     "customManagers": [
         {
             "groupName": "Debian/Ubuntu packages",
@@ -62,11 +61,7 @@
             "matchDatasources": ["npm"],
             "matchUpdateTypes": ["major"],
             "enabled": false,
-            "description": "Disable major version upgrades for all npm packages"
+            "description": "Disable major version upgrades for all npm packages. Useful to avoid Vue 2 to Vue 3 and Carbon upgrades."
         }
-    ],
-    "lockFileMaintenance": {
-        "enabled": true,
-        "schedule": ["before 5am on the first day of the month"]
-    }
+    ]
 }

--- a/ns8.json
+++ b/ns8.json
@@ -10,6 +10,16 @@
         "enabled": true,
         "ignoreDeps": ["vue"]
     },
+    "rebaseWhen": "never",
+    "keepUpdatedLabel": "auto-update",
+    "packageRules": [
+        {
+            "matchDatasources": ["npm"],
+            "matchUpdateTypes": ["major"],
+            "enabled": false,
+            "description": "Disable major version upgrades for all npm packages. Useful to avoid Vue 2 to Vue 3 and Carbon upgrades."
+        }
+    ],
     "customManagers": [
         {
             "groupName": "Debian/Ubuntu packages",
@@ -54,14 +64,6 @@
                 "(?<depName>(?:ghcr|quay)\\.io\\/[-0-9a-z_\\/.]+):(?<currentValue>[-0-9a-zA-Z_.]+)"
             ],
             "datasourceTemplate": "docker"
-        }
-    ],
-    "packageRules": [
-        {
-            "matchDatasources": ["npm"],
-            "matchUpdateTypes": ["major"],
-            "enabled": false,
-            "description": "Disable major version upgrades for all npm packages. Useful to avoid Vue 2 to Vue 3 and Carbon upgrades."
         }
     ]
 }

--- a/vue3.json
+++ b/vue3.json
@@ -1,0 +1,15 @@
+{
+	"$schema": "https://docs.renovatebot.com/renovate-schema.json",
+	"extends": [
+		"local>NethServer/.github:base",
+		":maintainLockFilesMonthly"
+	],
+	"packageRules": [
+		{
+			"matchManagers": [
+				"npm"
+			],
+			"rangeStrategy": "replace"
+		}
+	]
+}


### PR DESCRIPTION
Add renovate presets:
- base: preset for all Nethserver/Nethesis repositories
- vue3: preset for repositories using Vue 3

ns8 preset now inherits from base preset.