### PR TITLE
fix: disable updates for Vue CLI monorepo

### DIFF
--- a/ns8.json
+++ b/ns8.json
@@ -33,7 +33,15 @@
             "matchDatasources": ["npm"],
             "matchUpdateTypes": ["major"],
             "enabled": false,
-            "description": "Disable major version upgrades for all npm packages. Useful to avoid Vue 2 to Vue 3 and Carbon upgrades."
+            "description": "Disable major version upgrades for all npm packages. Useful to avoid major updates of Vue ecosystem and Carbon."
+        },
+        {
+            "description": "Disable updates for Vue CLI monorepo packages to avoid node and @achrinza/node-ipc compatibility issues",
+            "matchPackagePatterns": [
+                "^@vue/cli-",
+                "@vue/cli"
+            ],
+            "enabled": false
         }
     ],
     "customManagers": [


### PR DESCRIPTION
Disable updates for `@vue/cli*` packages in `ns8` preset.

This is needed because of incompatibility between `@achrinza/node-ipc` (dependency of vue-cli 4.5.19) and node >= 18.

Furthermore, NS8 modules will have to lock vue-cli version to exactly 4.5.13 (the one currently used) in order to perform lock file maintenance succesfully.