### PR TITLE
fix: remove lockFileMaintenance for ns8 preset

### DIFF
--- a/ns8.json
+++ b/ns8.json
@@ -1,8 +1,7 @@
 {
     "$schema": "https://docs.renovatebot.com/renovate-schema.json",
     "extends": [
-        "local>NethServer/.github:base",
-        ":maintainLockFilesMonthly"
+        "local>NethServer/.github:base"
     ],
     "branchPrefix": "renovate-",
     "branchNameStrict": true,


### PR DESCRIPTION
Remove lock file maintenance for NS8. If we keep the NPM lock file updated the build breaks:
- some new indirect dependencies (e.g. `@achrinza/node-ipc`) require Node < 18
- other indirect dependencies (`minimatch`) require Node >= 20