### PR TITLE
ci(renovate): add minimumReleaseAge for supply chain protection

### DIFF
--- a/base.json
+++ b/base.json
@@ -5,5 +5,6 @@
         ":disableDependencyDashboard",
         ":enableVulnerabilityAlerts"
     ],
-    "osvVulnerabilityAlerts": true
+    "osvVulnerabilityAlerts": true,
+    "minimumReleaseAge": "5 days"
 }


### PR DESCRIPTION
Add a 5-day grace period before updating to new package releases. This mitigates supply chain attack risks by allowing community detection and vetting before automated updates are applied.

The minimumReleaseAge setting will be inherited by all repositories using this base configuration.