### PR TITLE
fix(ns8): disable updates for @carbon/icons-vue

### DIFF
--- a/ns8.json
+++ b/ns8.json
@@ -41,6 +41,13 @@
                 "@vue/cli"
             ],
             "enabled": false
+        },
+        {
+            "description": "Disable updates for @carbon/icons-vue 10.129.0 and later, due to compatibility issues",
+            "matchPackageNames": [
+                "@carbon/icons-vue"
+            ],
+            "allowedVersions": "<10.129.0"
         }
     ],
     "customManagers": [


### PR DESCRIPTION
Disable updates for @carbon/icons-vue 10.129.0 and later, due to compatibility issues with the current build system.

See: https://github.com/NethServer/ns8-dependencytrack/pull/99