### PR TITLE
revert(ns8): re-enable updates for @carbon/icons-vue

### DIFF
--- a/ns8.json
+++ b/ns8.json
@@ -41,13 +41,6 @@
                 "@vue/cli"
             ],
             "enabled": false
-        },
-        {
-            "description": "Disable updates for @carbon/icons-vue 10.129.0 and later, due to compatibility issues",
-            "matchPackageNames": [
-                "@carbon/icons-vue"
-            ],
-            "allowedVersions": "<10.129.0"
         }
     ],
     "customManagers": [


### PR DESCRIPTION
Reverts #14.

After upgrading yarn from v1 to v4, newer versions of `@carbon/icons-vue` are compatible with the NS8 UI build system. The version restriction introduced in #14 is therefore no longer needed and can be removed.

Yarn upgrade example:
- https://github.com/NethServer/ns8-matrix/pull/80/changes/56199a9fc645bc4bf541e92ff3ee086b245eb8ba